### PR TITLE
Set log level via env var 

### DIFF
--- a/test.py
+++ b/test.py
@@ -23,8 +23,9 @@ import time
 FORMAT = '[%(asctime)s][%(name)s][%(process)d %(processName)s][%(levelname)-8s] (L:%(lineno)s) %(funcName)s: %(message)s'
 logging.basicConfig(format=FORMAT, datefmt='%Y-%m-%d %H:%M:%S')
 LOG = logging.getLogger(__name__)
-# change to DEBUG for full output
-LOG.setLevel(logging.INFO)
+# By default the logging level would be INFO
+log_level = os.environ.get('DEFAULT_LOG', 'INFO').upper()
+LOG.setLevel(log_level)
 
 
 def get_last_id(db_user, db_name, db_pass, db_host):


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->

- [x] Functional change
- [x] New feature

### Pull request long description:
1. Logging level can be set via an env var `DEFAULT_LOG` keeping it consistent to what we have in other helm charts.

### Changes made:
1. `DEFAULT_LOG` can take logging level, when none provided defaults to `INFO`

### Related issues:
Fixes #18