### PR TITLE
Fix Wrong parameter order for s3

### DIFF
--- a/test.py
+++ b/test.py
@@ -347,8 +347,8 @@ def main():
         submit_cega(cm_protocol, config['cm_address'], config['cm_user'], config['cm_vhost'],
                     {'file_id': fileID, 'stable_id': stableID}, 'stableIDs',
                     config['cm_pass'], correlation_id, port=config['cm_port'])
-        list_s3_objects(config['s3_address'], config['s3_region'],
-                        config['s3_bucket'], fileID,
+        list_s3_objects(config['s3_address'], config['s3_bucket'],
+                        config['s3_region'], fileID,
                         config['s3_access'], config['s3_secret'])
     LOG.debug('Ingestion DONE')
     LOG.debug('-------------------------------------')


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
Wrong parameter order for s3.

### Changes made:
1. Changed the `list_s3_objects` parameter order

### Mentions:
Sorry @jonandernovella 
