### PR TITLE
Requests verify download with root CA

### DIFF
--- a/lega_tester/test.py
+++ b/lega_tester/test.py
@@ -75,7 +75,7 @@ def test_step_res_download(config, filename, fileID, used_file, session_key, iv)
     # download_to_file(res_url, res_payload, res_file,
     #                  config['tls_cert_tester'],
     #                  config['tls_key_tester'])
-    download_to_file(res_url, res_payload, res_file)
+    download_to_file(config['tls_ca_root_file'], res_url, res_payload, res_file)
     compare_files('RES', res_file, used_file)
 
 
@@ -91,7 +91,7 @@ def test_step_dataedge_download(config, filename, stableID, used_file):
     # download_to_file(dataedge_url, edge_payload, dataedge_file,
     #                  config['tls_cert_tester'],
     #                  config['tls_key_tester'], headers=edge_headers)
-    download_to_file(dataedge_url, edge_payload, dataedge_file, headers=edge_headers)
+    download_to_file(config['tls_ca_root_file'], dataedge_url, edge_payload, dataedge_file, headers=edge_headers)
     compare_files('DataEdge', dataedge_file, used_file)
 
 

--- a/lega_tester/utils.py
+++ b/lega_tester/utils.py
@@ -23,14 +23,12 @@ def strip_url_scheme(url):
     return parsed.geturl().replace(scheme, '', 1)
 
 
-def download_to_file(service, payload, output, headers=None):
+def download_to_file(root_ca, service, payload, output, headers=None):
     """Download file from service and write to file."""
     if headers:
-        # download = requests.get(service, params=payload, headers=headers, cert=(test_cert, test_key_file))
-        download = requests.get(service, params=payload, headers=headers, verify=False)
+        download = requests.get(service, params=payload, headers=headers, verify=(root_ca))
     else:
-        # download = requests.get(service, params=payload, cert=(test_cert, test_key_file))
-        download = requests.get(service, params=payload, verify=False)
+        download = requests.get(service, params=payload, verify=(root_ca))
     # We are using filecmp thus we will write content to file
     LOG.debug(f'Download url is: {download.url}')
     assert download.status_code == 200, f'We got a status that is not OK {download.status_code} | FAIL |'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lega_tester',
-    version='0.2.0',
+    version='0.3.0',
     packages=find_packages(),
     py_modules=['lega_tester'],
     include_package_data=True,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup

### Pull request long description:
Now download requests include a root CA for verification so we don't get the error:
```
/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
```

### Changes made:
1. added `verify=(root_ca)` to requests
2. bumped version
