### PR TITLE
Add encryption with crypt4gh@v1.0 and support new services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine3.8 as BUILD
+FROM python:3.6-alpine3.10 as BUILD
 
 RUN apk add --no-cache git postgresql-libs postgresql-dev gcc musl-dev libffi-dev make gnupg && \
     rm -rf /var/cache/apk/*
@@ -11,7 +11,7 @@ RUN pip install --upgrade pip && \
     pip install -r /root/legatester/requirements.txt && \
     pip install /root/legatester
 
-FROM python:3.6-alpine3.8
+FROM python:3.6-alpine3.10
 
 LABEL maintainer "NeIC System Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ localega:
   # User secret private RSA key.
   user_key: /config/dummy.key
   # Public key file to encrypt file.
+  # This is also the recipient public key
   encrypt_key_public: /config/key.1.pub
   # Private key file to encrypt file.
   encrypt_key_private: /config/key.1.sec

--- a/config.yaml
+++ b/config.yaml
@@ -15,10 +15,20 @@ localega:
   tls_cert_tester: /config/tester.ca.crt
   tls_key_tester: /config/tester.ca.key
   tls_ca_root_file: /config/root.ca.crt
+  # If inbox_s3 set to true it will ignore
+  # sftp inbox parameters
+  inbox_s3: false
+  inbox_s3_address: localega-s3-inbox
+  inbox_s3_access:
+  inbox_s3_secret:
+  inbox_s3_region: lega
+  inbox_s3_ssl: false
+  # Parameters for SFTP based inbox
   inbox_address: localega-inbox
   inbox_port: 2222
   data_storage_type: "S3Storage" # S3Storage or FileStorage
-  # S3 address, or service name, should include port number
+
+  # S3 Archive address, or service name, should include port number
   # if s3_address includes `http` it will be removed
   s3_ssl: false
   s3_address:

--- a/config.yaml
+++ b/config.yaml
@@ -48,9 +48,6 @@ localega:
   cm_user:
   cm_vhost:
   cm_pass:
-  # RES address or service name and port
-  res_address: localega-res
-  res_port: 9090
   # DataEdge address or service name and port
   dataedge_address: localega-dataedge
   dataedge_port: 9059

--- a/config.yaml
+++ b/config.yaml
@@ -48,9 +48,9 @@ localega:
   cm_user:
   cm_vhost:
   cm_pass:
-  # DataEdge address or service name and port
-  dataedge_address: localega-dataedge
-  dataedge_port: 9059
+  # DOA address or service name and port
+  doa_address: localega-doa
+  doa_port: 8080
   # DB address, port will be assumed 5432
   db_ssl: false
   db_address: localega-db

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,8 @@ localega:
   inbox_s3_secret:
   inbox_s3_region: lega
   inbox_s3_ssl: false
+  # if the S3 Inbox is public set this below true
+  inbox_s3_public: false
   # Parameters for SFTP based inbox
   inbox_address: localega-inbox
   inbox_port: 2222
@@ -31,6 +33,8 @@ localega:
   # S3 Archive address, or service name, should include port number
   # if s3_address includes `http` it will be removed
   s3_ssl: false
+  # if the S3 Archive is public set this below true
+  s3_public: false
   s3_address:
   s3_access:
   s3_secret:

--- a/lega_tester/test.py
+++ b/lega_tester/test.py
@@ -95,20 +95,20 @@ def test_step_check_archive(config, fileID):
         LOG.debug(f'Found ingested file: {file_path.name} of size: {file_path.stat().st_size}.')
 
 
-def test_step_dataedge_download(config, filename, stableID, used_file):
-    """Test download from DataEdge service."""
-    # Verify that the file can be downloaded from DataEdge
-    # We are using a token that can be validated by DataEdge
+def test_step_doa_download(config, filename, stableID, used_file):
+    """Test download from doa service."""
+    # Verify that the file can be downloaded from doa
+    # We are using a token that can be validated by doa
     token = config['token']
-    dataedge_file = f'/volume/{filename}.dataedge'
+    doa_file = f'/volume/{filename}.doa'
     edge_payload = {'destinationFormat': 'plain'}
     edge_headers = {'Authorization': f'Bearer {token}'}  # No token no permissions
-    dataedge_url = f"https://{config['dataedge_address']}:{config['dataedge_port']}/files/{stableID}"
-    # download_to_file(dataedge_url, edge_payload, dataedge_file,
+    doa_url = f"https://{config['doa_address']}:{config['doa_port']}/files/{stableID}"
+    # download_to_file(doa_url, edge_payload, doa_file,
     #                  config['tls_cert_tester'],
     #                  config['tls_key_tester'], headers=edge_headers)
-    download_to_file(config['tls_ca_root_file'], dataedge_url, edge_payload, dataedge_file, headers=edge_headers)
-    compare_files('DataEdge', dataedge_file, used_file)
+    download_to_file(config['tls_ca_root_file'], doa_url, edge_payload, doa_file, headers=edge_headers)
+    compare_files('doa', doa_file, used_file)
 
 
 # FIXTURES
@@ -152,7 +152,7 @@ def fixture_step_encrypt(config, original_file):
 def fixture_step_completed(config, current_id, output_base):
     """Test if file has completed both in MQ and in DB."""
     # Once the file has been ingested it should be the last ID in the database
-    # We use this ID everywhere including donwload from DataEdge
+    # We use this ID everywhere including donwload from doa
     # In future versions once we fix DB schema we will use StableID for download
     cm_protocol = 'amqps' if config['cm_ssl'] else 'amqp'
     # wait for submission to go through
@@ -221,8 +221,8 @@ def dependency_make_cega_stableID(config, fileID, correlation_id, stableID):
 
 
 def dependency_map_file2dataset(config, fileID):
-    """Map file to dataset for retrieving file via dataedge."""
-    LOG.debug('Mapping file to dataset for retrieving file via dataedge.')
+    """Map file to dataset for retrieving file via doa."""
+    LOG.debug('Mapping file to dataset for retrieving file via doa.')
 
     # There is no component asigning permissions for files in datasets
     # Thus we need this step
@@ -297,7 +297,7 @@ def main():
     LOG.debug('-------------------------------------')
 
     dependency_map_file2dataset(config, fileID)
-    test_step_dataedge_download(config, filename, stableID, original_file)
+    test_step_doa_download(config, filename, stableID, original_file)
 
     LOG.debug('Outgestion DONE')
     LOG.debug('-------------------------------------')

--- a/lega_tester/test.py
+++ b/lega_tester/test.py
@@ -73,22 +73,6 @@ def test_step_check_archive(config, fileID):
         LOG.debug(f'Found ingested file: {file_path.name} of size: {file_path.stat().st_size}.')
 
 
-def test_step_res_download(config, filename, fileID, used_file, session_key, iv):
-    """Test download from RES service.
-
-    Not necessary but good to have and see before testing dataedge
-    """
-    # Verify that the file can be downloaded from RES using the session_key and IV
-    res_file = f'/volume/{filename}.res'
-    res_payload = {'sourceKey': session_key, 'sourceIV': iv, 'filePath': fileID}
-    res_url = f"https://{config['res_address']}:{config['res_port']}/file"
-    # download_to_file(res_url, res_payload, res_file,
-    #                  config['tls_cert_tester'],
-    #                  config['tls_key_tester'])
-    download_to_file(config['tls_ca_root_file'], res_url, res_payload, res_file)
-    compare_files('RES', res_file, used_file)
-
-
 def test_step_dataedge_download(config, filename, stableID, used_file):
     """Test download from DataEdge service."""
     # Verify that the file can be downloaded from DataEdge
@@ -293,7 +277,6 @@ def main():
     ensure_db_status(config, fileID, "READY")
     LOG.debug('Ingestion DONE')
     LOG.debug('-------------------------------------')
-    test_step_res_download(config, filename, fileID, original_file, session_key, iv)
 
     dependency_map_file2dataset(config, fileID)
     test_step_dataedge_download(config, filename, stableID, original_file)

--- a/lega_tester/test.py
+++ b/lega_tester/test.py
@@ -43,17 +43,22 @@ def test_step_upload(config, test_user, test_file):
     """Do the first step of the test, send file to inbox."""
     # Test Inbox Connection before anything
     if config['inbox_s3']:
+        verify_s3_inbox_ssl = False
+        if config['inbox_s3_public'] and config['s3_ssl']:
+            verify_s3_inbox_ssl = True
+        elif config['s3_ssl']:
+            verify_s3_inbox_ssl = config['tls_ca_root_file']
         # Assumes each user has a bucket
         s3_connection(config['inbox_s3_address'], test_user,
                       config['inbox_s3_region'],
                       config['inbox_s3_access'], config['inbox_s3_secret'],
                       config['inbox_s3_ssl'],
-                      config['tls_ca_root_file'])
+                      verify_s3_inbox_ssl)
         s3_upload(config['inbox_s3_address'], test_user,
                   config['inbox_s3_region'], test_file,
                   config['inbox_s3_access'], config['inbox_s3_secret'],
                   config['inbox_s3_ssl'],
-                  config['tls_ca_root_file'])
+                  verify_s3_inbox_ssl)
     else:
         key_pk = os.path.expanduser(config['user_key'])
         open_ssh_connection(config['inbox_address'], test_user, key_pk, port=int(config['inbox_port']))
@@ -68,17 +73,22 @@ def test_step_check_archive(config, fileID):
     else:
         storage_type = "S3Storage"
     if storage_type == "S3Storage":
+        verify_s3_ssl = False
+        if config['s3_public'] and config['s3_ssl']:
+            verify_s3_ssl = True
+        elif config['s3_ssl']:
+            verify_s3_ssl = config['tls_ca_root_file']
         check_file_exists(config['s3_address'], config['s3_bucket'],
                           config['s3_region'], fileID,
                           config['s3_access'], config['s3_secret'],
                           config['s3_ssl'],
-                          config['tls_ca_root_file'])
+                          verify_s3_ssl)
         # While we are at it let us see what is inside the S3 Archive
         list_s3_objects(config['s3_address'], config['s3_bucket'],
                         config['s3_region'], fileID,
                         config['s3_access'], config['s3_secret'],
                         config['s3_ssl'],
-                        config['tls_ca_root_file'])
+                        verify_s3_ssl)
     elif storage_type == "FileStorage":
         assert Path.is_file(f'/ega/archive/{fileID}'), f"Could not find the file just uploaded! | FAIL | "
         file_path = Path(f'/ega/archive/{fileID}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ paramiko
 boto3
 PyYAML
 requests
-git+https://github.com/neicnordic/LocalEGA-cryptor.git
+crypt4gh @ git+https://github.com/EGA-archive/crypt4gh.git@v1.0
 psycopg2-binary
 tenacity

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lega_tester',
-    version='0.4.0',
+    version='0.4.1',
     packages=find_packages(),
     py_modules=['lega_tester'],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'requests',
         'psycopg2-binary',
         'tenacity',
-        'legacryptor @ git+https://github.com/neicnordic/LocalEGA-cryptor',
+        'crypt4gh @ git+https://github.com/EGA-archive/crypt4gh.git@v1.0',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
We will be using new crypt4gh algorithm for encryption https://github.com/EGA-archive/crypt4gh/tree/v1.0 and We will deprecate some services such as RES in favor of https://github.com/neicnordic/LocalEGA-DOA . We will support also S3 inbox instead of sftp based one.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. Removed RES download test
2. Added encryption with crypt4gh@v1.0
3. Bumped version
4. S3 inbox support - **Not tested**

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

` e2e tester should work with new services.` on Tryggve2 SDA board

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Added support also for S3Inbox, however unable to test, if @viklund or @jbygdell can take a look when you have an s3inbox ready, and suggest any other changes required.