### PR TITLE
Bugfix missing filepath for FileStorage type

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,7 @@ localega:
   inbox_address: localega-inbox
   inbox_port: 2222
   data_storage_type: "S3Storage" # S3Storage or FileStorage
-
+  data_storage_location: /ega/archive
   # S3 Archive address, or service name, should include port number
   # if s3_address includes `http` it will be removed
   s3_ssl: false

--- a/lega_tester/db_ops.py
+++ b/lega_tester/db_ops.py
@@ -83,3 +83,19 @@ def file2dataset_map(db_user, db_name, db_pass, db_host, file_id, dataset_id, ss
         LOG.debug(f"Mapped ID: {file_id} to Dataset: {dataset_id}")
         conn.commit()
     conn.close()
+
+
+def retrieve_file_path(db_user, db_name, db_pass, db_host, file_id, ssl_enable):
+    """Retrieve the archive path of file in the database, indifferent of status."""
+    conn = psycopg2.connect(user=db_user, password=db_pass,
+                            database=db_name, host=db_host,
+                            # We might need to use `verify-ca`
+                            # but for standard ssl connection `require` is eneough
+                            sslmode='require' if ssl_enable else 'disable')
+    cursor = conn.cursor()
+    cursor.execute('SELECT archive_path FROM local_ega.files where id = %(file_id)s', {"file_id": file_id})
+    archive_path = cursor.fetchone()[0]
+    LOG.debug(f"Archive path: {archive_path}")
+    cursor.close()
+    conn.close()
+    return archive_path

--- a/lega_tester/test.py
+++ b/lega_tester/test.py
@@ -7,7 +7,7 @@ import argparse
 import yaml
 from .utils import download_to_file, compare_files, is_none_p, read_enc_file_values
 from .archive_ops import list_s3_objects, check_file_exists
-from .db_ops import get_last_id, ensure_db_status, file2dataset_map
+from .db_ops import get_last_id, ensure_db_status, file2dataset_map, retrieve_file_path
 from .mq_ops import submit_cega, get_corr, purge_cega_mq
 from .inbox_ops import encrypt_file, open_ssh_connection, sftp_upload, sftp_remove
 from .inbox_ops import s3_connection, s3_upload
@@ -90,8 +90,12 @@ def test_step_check_archive(config, fileID):
                         config['s3_ssl'],
                         verify_s3_ssl)
     elif storage_type == "FileStorage":
-        assert Path.is_file(f'/ega/archive/{fileID}'), f"Could not find the file just uploaded! | FAIL | "
-        file_path = Path(f'/ega/archive/{fileID}')
+        archive_path = retrieve_file_path(config['db_in_user'], config['db_name'],
+                                          config['db_in_pass'], config['db_address'],
+                                          fileID,
+                                          config['db_ssl'])
+        file_path = Path(f"{config['data_storage_location']}/lega{archive_path}")
+        assert Path.is_file(file_path), f"Could not find the file just uploaded! | FAIL | "
         LOG.debug(f'Found ingested file: {file_path.name} of size: {file_path.stat().st_size}.')
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lega_tester',
-    version='0.4.1',
+    version='0.4.2',
     packages=find_packages(),
     py_modules=['lega_tester'],
     include_package_data=True,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->
When testing with FileStorage the archive path was not properly constructed

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. retrieve `archive_path` from database
2. add in test.py proper way of determining the file for `FileStorage`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
testing an installation with NFS

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
related to: https://github.com/NBISweden/LocalEGA-helm/pull/62
